### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/scintilla/lexlib/WordList.cxx
+++ b/scintilla/lexlib/WordList.cxx
@@ -103,7 +103,7 @@ void WordList::Clear() {
 #ifdef _MSC_VER
 
 static bool cmpWords(const char *a, const char *b) {
-	return strcmp(a, b) == -1;
+	return strcmp(a, b) < 0;
 }
 
 #else


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

You are using sorting of wordlists with std::sort function where called comparison function, which must return **true** if first word is less than second one. But for MSC_VER compilation you're defined comparison function, which return true only if **first** letter of first word is less than first letter of the second word.
The right comparison must check all letters, therefore you need to return true if strcmp < 0.

[V698] (https://www.viva64.com/en/w/v698/) Expression 'strcmp(....) == -1' is incorrect. This function can return not only the value '-1', but any negative value. Consider using 'strcmp(....) < 0' instead. wordlist.cxx 106
